### PR TITLE
Descriptionタグを修正

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,8 +16,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-
-      content="高松市のオープンデータを地図とAPI形式で配信しています。ウェブサイトやアプリケーションに地図を埋め込んでプログラミングできます。"
+      content="高松市スマートマップ & 都市情報APIは、高松市のオープンデータを地図とAPI形式で配信しています。都市計画図等のデータを、ウェブサイトやアプリケーションに地図を埋め込んでプログラミングできます。"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <meta name="apple-mobile-web-app-title" content="高松市スマートマップ & 都市情報API">


### PR DESCRIPTION
SEOのキーワード、「高松市スマートマップ」と「都市計画図」という単語が入った文章に変更しました。