### PR TITLE
URLや電話番号をリンクに変換する

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -5,6 +5,8 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
+  pull_request:
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -22,11 +24,24 @@ concurrency:
 
 jobs:
   # Single deploy job since we're just deploying
+  test:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: npm install
+      - name: Test
+        run: npm run test
+
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    '@babel/preset-typescript',
+  ],
+};

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/SidebarDetail.scss
+++ b/src/SidebarDetail.scss
@@ -51,6 +51,9 @@
       line-height: 22px;
       color: #FFFFFF;
       overflow-wrap: break-word;
+      a {
+        color: #FFFFFF;
+      }
     }
   }
 }

--- a/src/SidebarDetail.tsx
+++ b/src/SidebarDetail.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { AiOutlineClose } from "react-icons/ai";
 import './SidebarDetail.scss'
 import { CatalogFeature } from './api/catalog';
+import ReplaceTextToLink from './utils/ReplaceTextToLink';
 
 const SingleFeatureTable: React.FC<{feature: CatalogFeature}> = ({feature}) => {
   const detailItems = Object.entries(feature.properties).filter(([key, _value]) => !key.startsWith('_viewer_'));
@@ -26,7 +27,7 @@ const SingleFeatureTable: React.FC<{feature: CatalogFeature}> = ({feature}) => {
         { detailItems.map(([key, value]) => (
           <tr className="sidebar-detail-item" key={key}>
             <th className='label'>{key}</th>
-            <td className='content'>{value}</td>
+            <td className='content'><ReplaceTextToLink text={value} /></td>
           </tr>
         ))}
       </tbody>

--- a/src/utils/ReplaceTextToLink.test.tsx
+++ b/src/utils/ReplaceTextToLink.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ReplaceTextToLink from './ReplaceTextToLink';
+
+
+describe('ReplaceTextToLink', () => {
+
+  test('should replace a telephone number with a link', () => {
+    const text = '（環境業務課）087-834-0389'
+    render(<ReplaceTextToLink text={text} />);
+
+    const linkElement = screen.getByRole('link', { name: /087-834-0389/i});
+    expect(linkElement).toBeInTheDocument();
+
+    const textElement = screen.getByText(/（環境業務課）/i);
+    expect(textElement).toBeInTheDocument();
+  });
+
+  test('should replace multiple telephone numbers with links', () => {
+    const text = '（環境業務課）087-834-0389（環境業務課）087-834-0389'
+    render(<ReplaceTextToLink text={text} />);
+
+    const linkElements = screen.getAllByRole('link');
+    expect(linkElements.length).toBe(2);
+  });
+
+  test('should not replace a no hyphen telephone number with a link', () => {
+    const text = '（環境業務課）0878340389'
+    render(<ReplaceTextToLink text={text} />);
+
+    const linkElement = screen.queryByRole('link');
+    expect(linkElement).not.toBeInTheDocument();
+  });
+
+  test('should not replace without 市外局番', () => {
+    const text = '（環境業務課）834-0389'
+    render(<ReplaceTextToLink text={text} />);
+
+    const linkElement = screen.queryByRole('link');
+    expect(linkElement).not.toBeInTheDocument();
+
+    const textElement = screen.getByText(/（環境業務課）834-0389/i);
+    expect(textElement).toBeInTheDocument();
+  });
+
+  test('should not replace invalid telephone number', () => {
+    const text = '0120-123-456-789'
+    render(<ReplaceTextToLink text={text} />);
+
+    const linkElement = screen.queryByRole('link');
+    expect(linkElement).not.toBeInTheDocument();
+
+    const textElement = screen.getByText(/0120-123-456-789/i);
+    expect(textElement).toBeInTheDocument();
+  });
+
+  test('replace url to link', () => {
+    const text = 'http://www.city.takamatsu.kagawa.jp（高松市）'
+    render(<ReplaceTextToLink text={text} />);
+
+    const linkElement = screen.getByRole('link', { name: /http:\/\/www.city.takamatsu.kagawa.jp/i});
+    expect(linkElement).toBeInTheDocument();
+
+    const textElement = screen.getByText(/（高松市）/i);
+    expect(textElement).toBeInTheDocument();
+  });
+
+  test('should replace multiple urls with links', () => {
+    const text = 'http://www.city.takamatsu.kagawa.jp（高松市）http://www.city.takamatsu.kagawa.jp（高松市）'
+    render(<ReplaceTextToLink text={text} />);
+
+    const linkElements = screen.getAllByRole('link');
+    expect(linkElements.length).toBe(2);
+  });
+
+  test('should replace a url with query to link', () => {
+    const text = 'http://www.city.takamatsu.kagawa.jp?query=1'
+    render(<ReplaceTextToLink text={text} />);
+
+    const linkElement = screen.getByRole('link', { name: /http:\/\/www.city.takamatsu.kagawa.jp\?query=1/i});
+    expect(linkElement).toBeInTheDocument();
+  });
+
+});

--- a/src/utils/ReplaceTextToLink.tsx
+++ b/src/utils/ReplaceTextToLink.tsx
@@ -1,0 +1,49 @@
+type Props = {
+  text: string
+}
+
+const ReplaceTextToLink = (props: Props) => {
+  const { text } = props;
+
+  if (typeof text !== 'string') {
+    return (<>{text}</>)
+  }
+
+  const urlRegex = /https?:\/\/[-_.!~*'()a-zA-Z0-9;/?:@&=+$,%#]+/g;
+  const telRegex = /0\d{1,4}-\d{1,4}-\d{4}/g;
+  const regex = new RegExp(`(${urlRegex.source}|${telRegex.source})`, 'g');
+
+  const parts = text.split(regex);
+
+  const result = parts.map((part, index) => {
+
+    if (part.match(urlRegex)) {
+      return (
+        <a
+          key={index}
+          href={part}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {part}
+        </a>
+      );
+    } else if (part.match(telRegex)) {
+      return (
+        <a
+          key={index}
+          href={`tel:${part}`}
+        >
+          {part}
+        </a>
+      );
+    }
+
+    return part;
+  });
+
+  return <>{result}</>;
+};
+
+
+export default ReplaceTextToLink


### PR DESCRIPTION
Close #78 

- 電話番号は 市外局番が省かれたもの（市内局番-加入者番号）は変換しないようにしています。（固定電話からしかかけられないため）


<img width="721" alt="スクリーンショット 2023-06-28 15 28 41" src="https://github.com/takamatsu-city/maps.takamatsu-fact.com/assets/8760841/14a5bce7-63ff-4005-aa71-6410b67ad79c">

