### PR TITLE
スマホで表示時に標高切り替えボタンがデータ詳細パネルの上に表示されていたので修正

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -73,7 +73,7 @@ body,
       height: 29px;
       padding: 0;
       width: 29px;
-      z-index: 10;
+      z-index: 2;
       border-radius: 4px;
       box-shadow: 0 0 0 2px rgba(0,0,0,.1);
 


### PR DESCRIPTION
<img width="528" alt="スクリーンショット 2024-04-16 17 20 58" src="https://github.com/takamatsu-city/maps.takamatsu-fact.com/assets/8760841/2b376b2f-7fbd-4683-a078-ed9a2624a2a3">
