### PR TITLE
地図の中心座標がずれて見える問題を修正

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -82,5 +82,18 @@ body,
         color: #058cd5;
       }
     }
+
+    .maplibregl-ctrl-bottom-right,
+    .maplibregl-ctrl-bottom-left {
+      bottom: 24px !important; //アトリビューションが重ならないように調整
+    }
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .map-container {
+    // データリストパネル分、地図の中心がずれないようにマージンを追加。
+    // 高さ（84px）を指定すると追加すると角丸（24px）の背景が見えるようになるので、60pxにしている。
+    margin-bottom: 60px;
   }
 }

--- a/src/App.scss
+++ b/src/App.scss
@@ -27,11 +27,8 @@ body,
     background: #F6F6F6;
     box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.22);
     width: 350px;
-    height: calc(100% - 60px);
     box-sizing: border-box;
     overflow: scroll;
-    position: absolute;
-    z-index: 1;
     transition: all 0.5s;
   }
 
@@ -50,10 +47,9 @@ body,
   }
 
   .map-container {
-    position: relative;
     flex-grow: 1;
     width: auto;
-    height: 100%;
+    height: auto;
     box-sizing: border-box;
 
     .map {

--- a/src/App.scss
+++ b/src/App.scss
@@ -39,7 +39,7 @@ body,
     box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.22);
     top: 0;
     bottom: 0;
-    left: 350px;
+    left: 0;
     width: 372px;
     box-sizing: border-box;
     overflow: scroll;
@@ -47,9 +47,10 @@ body,
   }
 
   .map-container {
+    position: relative;
     flex-grow: 1;
     width: auto;
-    height: auto;
+    height: 100%;
     box-sizing: border-box;
 
     .map {
@@ -82,18 +83,18 @@ body,
         color: #058cd5;
       }
     }
-
-    .maplibregl-ctrl-bottom-right,
-    .maplibregl-ctrl-bottom-left {
-      bottom: 24px !important; //アトリビューションが重ならないように調整
-    }
   }
 }
 
 @media screen and (max-width: 768px) {
   .map-container {
-    // データリストパネル分、地図の中心がずれないようにマージンを追加。
+    // データリストパネル分、地図の中心がずれないように余白を追加。
     // 高さ（84px）を指定すると追加すると角丸（24px）の背景が見えるようになるので、60pxにしている。
-    margin-bottom: 60px;
+    padding-bottom: 60px;
+
+    .maplibregl-ctrl-bottom-right,
+    .maplibregl-ctrl-bottom-left {
+      bottom: 24px !important; //アトリビューションが重ならないように調整
+    }
   }
 }


### PR DESCRIPTION
Close #140 #139 

以下の2つに関連する問題だったので、つのPRにしました。すみませんがよろしくお願いします。🙇‍♂️

- [地図がサイドバーに隠れているため地図の中心座標がずれて見える #139](https://github.com/takamatsu-city/maps.takamatsu-fact.com/issues/139) 
- [スマートフォンで地図を表示した時にアトリビューションが隠れている#140](https://github.com/takamatsu-city/maps.takamatsu-fact.com/issues/140) 