### PR TITLE
許可盛土データの更新

### DIFF
--- a/public/api/catalog.json
+++ b/public/api/catalog.json
@@ -1436,7 +1436,7 @@
         "name": "許可盛土",
         "class": "許可盛土",
         "source_type": "vector",
-        "tileUrl": "https://tileserver.geolonia.com/takamatsu_morido_allowed_260330/tiles.json?key=YOUR-API-KEY",
+        "tileUrl": "https://tileserver.geolonia.com/takamatsu_morido_allowed_260427/tiles.json?key=YOUR-API-KEY",
         "customDataSourceLayer": "許可盛土",
         "metadata": {
           "attributesOrder": [


### PR DESCRIPTION
* 許可盛土データの更新（260330 → 260427）
* ID:0111（高建指第２号）を追加
* 関連: geolonia/takamatsu-ops-2026#24, geolonia/takamatsu-ops-2026#30