### PR TITLE
地番現況図レイヤを追加

### DIFF
--- a/public/api/catalog.json
+++ b/public/api/catalog.json
@@ -39,8 +39,7 @@
     "tileUrl": "https://takamatsu-city.kagawa.smartcity.geolonia.com/data/chiban-genkyo-zu/latest/tiles/tiles.json",
     "customDataSourceLayer": "g-simplestyle-v1",
     "metadata": {
-      "attributesOrder": ["町名", "地番"],
-      "disclaimer": "本データは資産税課窓口で紙閲覧対応している資料を参考用に表示しているものです。法的効力を持つ情報ではありません。（暫定文面・本番反映前に正式文面に差し替え）"
+      "attributesOrder": ["町名", "地番"]
     }
   },
   {

--- a/public/api/catalog.json
+++ b/public/api/catalog.json
@@ -30,6 +30,20 @@
     "metadata": {}
   },
   {
+    "type": "DataItem",
+    "id": "地番現況図",
+    "shortId": "cGz",
+    "name": "地番現況図",
+    "class": "地番現況図",
+    "source_type": "vector",
+    "tileUrl": "https://takamatsu-city.kagawa.smartcity.geolonia.com/data/chiban-genkyo-zu/latest/tiles/tiles.json",
+    "customDataSourceLayer": "g-simplestyle-v1",
+    "metadata": {
+      "attributesOrder": ["町名", "地番"],
+      "disclaimer": "本データは資産税課窓口で紙閲覧対応している資料を参考用に表示しているものです。法的効力を持つ情報ではありません。（暫定文面・本番反映前に正式文面に差し替え）"
+    }
+  },
+  {
     "type": "Category",
     "id": "都市計画情報",
     "shortId": "40Q",

--- a/src/MainMap.tsx
+++ b/src/MainMap.tsx
@@ -213,6 +213,9 @@ const MainMap: React.FC<Props> = (props) => {
         const thirdPartySourceIds = thirdPartySource.map(item => item.sourceId).filter((id) => id !== 'v3' && !id.startsWith('ksj_'));
         const allFeatures = map
           .queryRenderedFeatures(e.point)
+          // 独自タイル(tileUrl)の Point はラベル用の代表点なので選択対象から除外する。
+          // 除外しないとポリゴン本体とラベル代表点の両方が拾われ、ポップアップが重複する（#20）。
+          .filter(feature => !(feature.geometry.type === 'Point' && tileUrlIds.includes(feature.source)))
           .filter(feature => (
             feature.source === 'takamatsu' ||
             feature.source === 'kihonzu' ||
@@ -528,7 +531,12 @@ const MainMap: React.FC<Props> = (props) => {
 
                   } else if ('tileUrl' in definition) {
                     layerConfig.source = definitionId;
-                    layerConfig['filter'] = (layerConfig['filter'] as any[])[1];
+                    // 独自タイルでは class フィルタは不要なので $type フィルタのみに絞るが、
+                    // サブテンプレートが独自フィルタ（例: ラベルを代表点=Point に限定）を持つ場合は
+                    // それを優先する。これを落とすとラベルがポリゴンに乗り、タイル境界で二重描画される（#20）。
+                    layerConfig['filter'] = subtemplate.filter
+                      ? subtemplate.filter
+                      : (layerConfig['filter'] as any[])[1];
                   }
 
                   if ('customDataSourceLayer' in definition) {

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -248,6 +248,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpenedSidebar, setIsOpenedSidebar, 
           <li>国土数値情報のうち、土砂災害警戒区域/小学校区/中学校区のデータは2023年度（令和5年度）時点のものです。高潮浸水想定区域/津波浸水想定/洪水浸水想定区域データ（想定最大規模・計画規模）は、<a href="https://disaportal.gsi.go.jp/hazardmapportal/hazardmap/copyright/opendata.html">ハザードマップポータルサイト</a>で配信されているタイルを利用しています（凡例はリンク先を参照してください）。</li>
           <li>国土数値情報のうち、小学校区/中学校区に関して、正確な情報は、<a href="https://www.city.takamatsu.kagawa.jp/smph/kurashi/kosodate/shouchugakkou/nyugaku/kouku-choumei.html">校区一覧のページ</a>でご確認ください。</li>
           <li>盛土規制法のうち、既存盛土等は、造成前後等の地形図等を基に抽出された盛土等の概ねの位置を示したものであり、直ちに危険性のある盛土等を示したものではありません。</li>
+          <li>地番現況図は、資産税課窓口で紙閲覧対応している資料を参考用に表示しているものです。法的効力を持つ情報ではありません。（暫定文面・本番反映前に正式文面に差し替え）</li>
         </ul>
       </details>
     </div>

--- a/src/utils/mapStyling.ts
+++ b/src/utils/mapStyling.ts
@@ -403,6 +403,18 @@ const AREA_STYLES: { [key: string]: CustomStyle[] } = {
       opacity: 0.3
     }
   ],
+  "地番現況図": [
+    {
+      id: "地番現況図",
+      fillColor: "rgba(255, 204, 102, 0.3)",
+      outlineColor: "rgb(153, 102, 0)",
+      lineColor: "rgb(153, 102, 0)",
+      lineWidth: 0.5,
+      opacity: 0.3,
+      labelField: "表示文字列",
+      labelMinZoom: 16
+    }
+  ],
   "届出盛土":[
     {
       id: "届出盛土",

--- a/src/utils/mapStyling.ts
+++ b/src/utils/mapStyling.ts
@@ -125,6 +125,10 @@ export type CustomStyle = {
   lineWidth?: any
   opacity?: number
   lineOpacity?: number
+  // Polygon の中心にラベルを出すための symbol layer 設定。labelField は属性名を渡す（例: "表示文字列"）。
+  labelField?: string
+  labelMinZoom?: number
+  labelTextSize?: number
 }
 
 const AREA_STYLES: { [key: string]: CustomStyle[] } = {
@@ -458,7 +462,7 @@ export type LayerTemplate = (LayerSpecification & {
 
 export const customStyleToPolygonTemplate: (customStyle: CustomStyle, defaultColor: string) => LayerTemplate[] = (style, color) => {
   const fillPaint = style.pattern ? { 'fill-pattern': style.pattern } : { 'fill-color': style.fillColor || color };
-  return [
+  const out: LayerTemplate[] = [
     {
       "id": `${style.id}`,
       source: "takamatsu",
@@ -483,6 +487,28 @@ export const customStyleToPolygonTemplate: (customStyle: CustomStyle, defaultCol
       },
     }
   ];
+  if (style.labelField) {
+    out.push({
+      "id": `${style.id}/label`,
+      source: "takamatsu",
+      "source-layer": "main",
+      type: "symbol",
+      filter: style.filter,
+      minzoom: style.labelMinZoom ?? 16,
+      layout: {
+        'text-field': ["get", style.labelField],
+        'text-size': style.labelTextSize ?? 12,
+        'text-anchor': 'center',
+        'text-font': ["Noto Sans Regular"],
+      },
+      paint: {
+        'text-color': '#333333',
+        'text-halo-color': '#ffffff',
+        'text-halo-width': 1,
+      },
+    });
+  }
+  return out;
 }
 
 export const customStyleToLineStringTemplate: (customStyle: CustomStyle, defaultColor: string) => LayerTemplate[] = (style, color) => [

--- a/src/utils/mapStyling.ts
+++ b/src/utils/mapStyling.ts
@@ -500,12 +500,19 @@ export const customStyleToPolygonTemplate: (customStyle: CustomStyle, defaultCol
     }
   ];
   if (style.labelField) {
+    // ラベルはポリゴン代表点(Point)にのみ乗せる。ポリゴン本体に乗せると、タイル境界を
+    // またぐポリゴンが各タイルにクリップされる際にラベルがタイルごとに描画され「同じ地番が
+    // 複数表示」になる(地番現況図 #20)。タイル側(build.sh)で各地番の代表点を生成済みのため、
+    // geometry-type=Point に限定することで 1地番=1ラベル となる。
+    const labelFilter: any = style.filter
+      ? ["all", style.filter, ["==", ["geometry-type"], "Point"]]
+      : ["==", ["geometry-type"], "Point"];
     out.push({
       "id": `${style.id}/label`,
       source: "takamatsu",
       "source-layer": "main",
       type: "symbol",
-      filter: style.filter,
+      filter: labelFilter,
       minzoom: style.labelMinZoom ?? 16,
       layout: {
         'text-field': ["get", style.labelField],
@@ -538,6 +545,12 @@ export const customStyleToLineStringTemplate: (customStyle: CustomStyle, default
 ];
 
 export const customStyleToPointTemplate: (customStyle: CustomStyle, defaultColor: string) => LayerTemplate[] = (style, color) => {
+  // labelField を持つスタイルは「ポリゴンのラベルを代表点(Point)に乗せる」用途。
+  // その代表点は描画対象にしない（ラベルは Polygon テンプレートの label レイヤが担当）。
+  // 描画すると点がドット表示され、低ズームで間引かれて見え方が安定しない（#20）。
+  if (style.labelField) {
+    return [];
+  }
   let out: LayerTemplate[] = [];
   if (style.pointLabel) {
     out.push({

--- a/src/utils/visibilityConversion.ts
+++ b/src/utils/visibilityConversion.ts
@@ -516,6 +516,10 @@ const displayConversion: DisplayConversionType = (features: CatalogFeature): Cat
       'A33_007':'公示日',
       'A33_008':'特別警戒未指定フラグ',
     },
+    '地番現況図': {
+      '大字名':'町名',
+      '表示文字列':'地番',
+    },
   }
 
   const featureClass = features.properties['class'] || features.catalog?.class;


### PR DESCRIPTION
## Summary

高松市の地番現況図（地籍図・地番図統合）を新規レイヤとして追加します。タイルは V3 カスタムタイル仕様で生成して `s3://takamatsu-city.kagawa.smartcity.geolonia.com/data/chiban-genkyo-zu/latest/` に配置済み。

このPRで現行スマートマップ（V1）から表示できるようにします。

## 変更内容

### コミット 1: `mapStyling: Polygon に label (symbol layer) 出力を追加`

汎用機構として、`AREA_STYLES` 内のレイヤ定義に `labelField` を指定すると、Polygon の中心にラベルを置く symbol layer が自動生成されるようになりました。

- `CustomStyle` 型に `labelField` / `labelMinZoom` / `labelTextSize` を追加
- `customStyleToPolygonTemplate` で `labelField` がある場合に symbol layer を出力

### コミット 2: `地番現況図レイヤを追加`

- `public/api/catalog.json`: 地番現況図エントリ（`tileUrl` + `customDataSourceLayer: g-simplestyle-v1`）
- `src/utils/mapStyling.ts` `AREA_STYLES["地番現況図"]`: fill 薄黄 / outline 茶 / 地番ラベル symbol（`labelField: "表示文字列"`, `labelMinZoom: 16`）
- `src/utils/visibilityConversion.ts` `translationMap["地番現況図"]`: 大字名→町名 / 表示文字列→地番 の表示変換 + 不要属性（大字CD等）の自動除去

## ブロッカー

- [ ] **geolonia/takamatsu-ops-2026#33 — 地番現況図 注意書き表示UI実装**: catalog `metadata.disclaimer` を画面に表示するUIが未実装。地番現況図は資産税課窓口閲覧資料を参考表示する性質上、注意書き表示が本番反映の必須要件（geolonia/takamatsu-ops-2026#20 のゴール記述）。**本PRはマージ不可**で、#33 完了後にDraftを外す。

## 関連 Issue

- 親 Issue: geolonia/takamatsu-ops-2026#20
- 子 Issue（ブロッカー）: geolonia/takamatsu-ops-2026#33
- 大本: geolonia/takamatsu-ops-2026#4

## 動作確認

ローカル dev server で zoom 9〜18 の各レベルおよびポップアップ動作を確認済み:

| 確認項目 | 結果 |
|---|---|
| レイヤパネル「地番現況図」表示 | ✅ |
| zoom 9 以上で fill+outline 表示 | ✅ マップ最低ズーム (`MainMap.tsx` `minZoom: 9`) から表示 |
| zoom 16 以上で地番ラベル表示 | ✅ 各区画中央に `8-15` `9-22` `10-1` 等の文字列 |
| クリックポップアップ | ✅ 「地番現況図 / 町名: 番町１丁目 / 地番: 8-15」 |
| 大字CD は表示されない | ✅ translationMap で町名/地番のみに絞り込み |
| 既存レイヤへの影響 | なし（`labelField` 未指定の他レイヤは挙動変わらず） |

## Test plan

- [ ] CI / typecheck (`tsc --noEmit`) 通過確認
- [ ] Netlify deploy preview で zoom 9 → 17 → 18 の表示確認
- [ ] Netlify deploy preview で番町1丁目あたりの区画クリック → ポップアップに 町名 / 地番 が出ることを確認
- [ ] 既存レイヤ（市道道路網図・コミュニティ協議会エリア・盛土規制法系）の表示が壊れていないこと
- [ ] **#33 完了後**にDraftを解除して再レビュー

## 備考

- タイル側の `tiles.json` 配信URL: https://takamatsu-city.kagawa.smartcity.geolonia.com/data/chiban-genkyo-zu/latest/tiles/tiles.json
- タイル生成スクリプトは別リポジトリ `geolonia/takamatsu-ops-2026` の `scripts/chiban-genkyo-zu/` に格納
- 本番反映は市民向け説明準備完了後（時期未定、四宮様@都市計画課と要調整）