### PR TITLE
県管理センサー（水位/潮位/降雨量）のサイドバー表示を かがわ防災Webポータル誘導に変更

### DIFF
--- a/src/SidebarDetail.scss
+++ b/src/SidebarDetail.scss
@@ -31,6 +31,25 @@
     }
   }
 
+  .kagawa-bousai-portal {
+    color: #FFFFFF;
+    font-size: 15px;
+    line-height: 22px;
+
+    .sensor-name {
+      font-weight: 700;
+      margin: 8px 0;
+    }
+
+    .portal-link {
+      margin: 8px 0;
+
+      a {
+        color: #FFFFFF;
+      }
+    }
+  }
+
   .sidebar-detail-item {
     border-bottom: 1.3px solid rgba(255, 255, 255, 0.1);
 

--- a/src/SidebarDetail.tsx
+++ b/src/SidebarDetail.tsx
@@ -8,7 +8,25 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { selectedFeaturesAtom } from './atoms';
 import ReplaceSpecialText from './utils/ReplaceSpecialText';
 
+const KAGAWA_BOUSAI_PORTAL_URL = 'https://www.bousai-kagawa.jp/dis_portal/';
+const KAGAWA_BOUSAI_PORTAL_CLASSES = new Set(['水位（県防災）', '潮位（県防災）', '降雨量']);
+
 const SingleFeatureTable: React.FC<{feature: CatalogFeature}> = ({feature}) => {
+  const featureClass = feature.catalog?.class;
+  if (typeof featureClass === 'string' && KAGAWA_BOUSAI_PORTAL_CLASSES.has(featureClass)) {
+    const sensorName = feature.properties['名称'] ?? '';
+    return (
+      <div className='kagawa-bousai-portal'>
+        {sensorName && <p className='sensor-name'>{sensorName}</p>}
+        <p className='portal-link'>
+          詳細内容については、
+          <a href={KAGAWA_BOUSAI_PORTAL_URL} target='_blank' rel='noopener noreferrer'>かがわ防災Webポータル</a>
+          をご確認ください。
+        </p>
+      </div>
+    );
+  }
+
   const detailItems = Object.entries(feature.properties).filter(([key, _value]) => !key.startsWith('_viewer_'));
   const attributesOrder = feature.catalog.metadata.attributesOrder ?? [];
 

--- a/src/cityos/lib/live_data_set.ts
+++ b/src/cityos/lib/live_data_set.ts
@@ -81,7 +81,13 @@ export default class LiveDataSet extends EventTarget {
   }
 
   private async _retrieveInitialDataSet() {
-    const initialDataResp = await fetch(`${WS_HTTP_URL}/channels/${this.id}/messages`);
+    // dev 環境ではバックエンドが API キー認証を要求する（v1 は未要求）。
+    // REACT_APP_API_KEY が設定されている場合のみ Authorization ヘッダーを送る。
+    const headers: HeadersInit = {};
+    if (process.env.REACT_APP_API_KEY) {
+      headers['Authorization'] = process.env.REACT_APP_API_KEY;
+    }
+    const initialDataResp = await fetch(`${WS_HTTP_URL}/channels/${this.id}/messages`, { headers });
     const initialDataJson = await initialDataResp.json();
 
     this.features = initialDataJson.data.map((data: any) => {


### PR DESCRIPTION
## 概要

- かがわ防災Webポータル更新（2026-04-01）以降、香川県管理データの機械的取得が停止しているため、該当センサーのサイドバー表示を測定値テーブルからポータル誘導に切り替える。
- 同様の対応を災対アプリ側で行った [geolonia/takamatsu-city-safety-map#239](https://github.com/geolonia/takamatsu-city-safety-map/pull/239) のスマートマップ版。
- 関連: [geolonia/takamatsu-ops-2026#29](https://github.com/geolonia/takamatsu-ops-2026/issues/29)（マイセーフティマップ側で起票された依頼。本PRはスマートマップにも横展開するもの）

## 変更内容

`src/SidebarDetail.tsx`:

- `feature.catalog.class` が `水位（県防災）` / `潮位（県防災）` / `降雨量` のいずれかの場合は、測定値テーブルではなく観測地点名（`properties['名称']`）と「詳細内容については、かがわ防災Webポータルをご確認ください。」のリンクを表示する。
- 市管理（`水位` / `潮位`）は従来通りテーブル表示を維持。
- ポータル URL は `KAGAWA_BOUSAI_PORTAL_URL` 定数で切り出し（`https://www.bousai-kagawa.jp/dis_portal/`）。

`src/SidebarDetail.scss`:

- 上記表示用に `.kagawa-bousai-portal` スタイル追加。

`src/cityos/lib/live_data_set.ts`:

- dev 環境で `api-ws-admin.geolonia.com` が API キー認証を要求するようになり、deploy preview で初期データ取得が 403 になっていたため、`REACT_APP_API_KEY` が設定されている場合のみ `Authorization` ヘッダーを付与する。
- 本番（v1）は当該 namespace に API キー未登録で認証スキップ枝に入るため、環境変数未設定で従来挙動を維持。
- PR #239 の [`689479fc`](https://github.com/geolonia/takamatsu-city-safety-map/pull/239/commits/689479fca396f2a16a50a288a7350cf6b7a2fa28) と同じ修正。

## 表示パターン整理

| データ種別 | 管理 | catalog.class | 表示 |
|---|---|---|---|
| 水位 | 市 | `水位` | 測定値テーブル（従来通り） |
| 水位（県防災） | 県 | `水位（県防災）` | **ポータル誘導リンク** |
| 潮位 | 市 | `潮位` | 測定値テーブル（従来通り） |
| 潮位（県防災） | 県 | `潮位（県防災）` | **ポータル誘導リンク** |
| 降雨量 | 県 | `降雨量` | **ポータル誘導リンク** |

## 確認していただきたい点

- リンク先 URL を `https://www.bousai-kagawa.jp/dis_portal/` で置いています（PR #239 と同一）。新ポータルの正式 URL が確定していれば差し替えます。

## テスト計画

- [x] `npx tsc --noEmit` パス
- [x] `npm run build` パス
- [x] `CI=true npm test -- --maxWorkers=2` 既存テスト全件パス（10/10）
- [x] ローカル起動で 3種クリック時にポータル誘導リンク表示・市管理2種が従来通りテーブル表示されることを目視確認
- [ ] deploy preview で 403 が解消され、IoTセンサーの表示が出ることを確認（要 Netlify 環境変数 `REACT_APP_API_KEY` の設定）

## 破壊的変更

なし。表示ロジックの分岐追加のみで、既存データ・カタログ定義・他コンポーネントには触っていない。