### PR TITLE
市立病院レイヤをサイドメニューから削除

### DIFF
--- a/public/api/catalog.json
+++ b/public/api/catalog.json
@@ -851,15 +851,6 @@
           },
           {
             "type": "DataItem",
-            "id": "施設情報/保健・医療・福祉/市立病院",
-            "shortId": "0qf",
-            "name": "市立病院",
-            "class": "市立病院",
-            "geojsonEndpoint": "https://opendata.takamatsu-fact.com/municipal_hospital/data.geojson",
-            "metadata": {}
-          },
-          {
-            "type": "DataItem",
             "id": "施設情報/保健・医療・福祉/小規模多機能型居宅介護施設",
             "shortId": "Vuz",
             "name": "小規模多機能型居宅介護施設",

--- a/src/utils/visibilityConversion.ts
+++ b/src/utils/visibilityConversion.ts
@@ -189,7 +189,6 @@ const displayConversion: DisplayConversionType = (features: CatalogFeature): Cat
     '陸上競技場': pattern1,
     '歴史・民俗施設': pattern1,
     'その他福祉施設': pattern1,
-    '市立病院': pattern1,
     '障がい福祉施設': pattern1,
     '地域包括支援センター': pattern1,
     '福祉会館・社会福祉協議会': pattern1,


### PR DESCRIPTION
## Summary
- 市立病院のデータ (`https://opendata.takamatsu-fact.com/municipal_hospital/data.geojson`) がホストされなくなったため、サイドメニューから削除する
- `public/api/catalog.json` から「市立病院」DataItem を削除
- `src/utils/visibilityConversion.ts` から「市立病院」のポップアップ表示設定を削除

## Test plan
- [ ] ローカルで `npm start` し、サイドメニューに「保健・医療・福祉 > 市立病院」が表示されないことを確認
- [ ] 既存の他のレイヤ（医療機関、小規模多機能型居宅介護施設 など隣接項目）が正常に表示されることを確認
- [ ] コンソールにエラーが出ないことを確認