### PR TITLE
非公開のGeoJSONデータのメニューを削除（井戸情報対応）

### DIFF
--- a/src/api/catalog.test.ts
+++ b/src/api/catalog.test.ts
@@ -1,0 +1,200 @@
+import { CatalogItem, filterUnavailableGeojsonItems } from "./catalog";
+
+type FetchMock = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+const installFetchMock = (handler: (url: string) => { status: number } | "throw") => {
+  const mock: FetchMock = async (input) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const result = handler(url);
+    if (result === "throw") {
+      throw new Error(`network error: ${url}`);
+    }
+    return new Response(null, { status: result.status });
+  };
+  (global as unknown as { fetch: FetchMock }).fetch = mock;
+};
+
+const geojsonItem = (id: string, url: string): CatalogItem => ({
+  type: "DataItem",
+  id,
+  shortId: id,
+  name: id,
+  class: id,
+  geojsonEndpoint: url,
+  metadata: {},
+});
+
+const vectorItem = (id: string): CatalogItem => ({
+  type: "DataItem",
+  id,
+  shortId: id,
+  name: id,
+  class: id,
+  metadata: {},
+});
+
+describe("filterUnavailableGeojsonItems", () => {
+  afterEach(() => {
+    delete (global as unknown as { fetch?: unknown }).fetch;
+  });
+
+  test("removes a geojson item whose endpoint returns 404", async () => {
+    installFetchMock((url) => (url.endsWith("/missing.geojson") ? { status: 404 } : { status: 200 }));
+
+    const input: CatalogItem[] = [
+      geojsonItem("ok", "https://example.com/ok.geojson"),
+      geojsonItem("missing", "https://example.com/missing.geojson"),
+    ];
+
+    const out = await filterUnavailableGeojsonItems(input);
+
+    expect(out.map((x) => x.id)).toEqual(["ok"]);
+  });
+
+  test("keeps a geojson item whose endpoint returns 200", async () => {
+    installFetchMock(() => ({ status: 200 }));
+
+    const input: CatalogItem[] = [geojsonItem("ok", "https://example.com/ok.geojson")];
+
+    const out = await filterUnavailableGeojsonItems(input);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe("ok");
+  });
+
+  test("keeps non-geojson items (vector, customDataSource, liveLocation) without probing", async () => {
+    const fetchCalls: string[] = [];
+    installFetchMock((url) => {
+      fetchCalls.push(url);
+      return { status: 200 };
+    });
+
+    const input: CatalogItem[] = [
+      vectorItem("vec"),
+      {
+        type: "DataItem",
+        id: "cds",
+        shortId: "cds",
+        name: "cds",
+        customDataSource: "src",
+        metadata: {},
+      },
+      {
+        type: "DataItem",
+        id: "live",
+        shortId: "live",
+        name: "live",
+        class: "live",
+        liveLocationId: "abc",
+        metadata: {},
+      },
+    ];
+
+    const out = await filterUnavailableGeojsonItems(input);
+
+    expect(out).toHaveLength(3);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  test("keeps a geojson item when the probe throws (network error)", async () => {
+    installFetchMock(() => "throw");
+
+    const input: CatalogItem[] = [geojsonItem("ok", "https://example.com/ok.geojson")];
+
+    const out = await filterUnavailableGeojsonItems(input);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe("ok");
+  });
+
+  test("keeps a geojson item on non-404 error responses (e.g. 500)", async () => {
+    installFetchMock(() => ({ status: 500 }));
+
+    const input: CatalogItem[] = [geojsonItem("ok", "https://example.com/ok.geojson")];
+
+    const out = await filterUnavailableGeojsonItems(input);
+
+    expect(out).toHaveLength(1);
+  });
+
+  test("filters items inside a Category and keeps the category", async () => {
+    installFetchMock((url) => (url.endsWith("/missing.geojson") ? { status: 404 } : { status: 200 }));
+
+    const input: CatalogItem[] = [
+      {
+        type: "Category",
+        id: "cat",
+        shortId: "cat",
+        name: "cat",
+        items: [
+          geojsonItem("ok", "https://example.com/ok.geojson"),
+          geojsonItem("missing", "https://example.com/missing.geojson"),
+        ],
+      },
+    ];
+
+    const out = await filterUnavailableGeojsonItems(input);
+
+    expect(out).toHaveLength(1);
+    const cat = out[0];
+    if (cat.type !== "Category") throw new Error("expected Category");
+    expect(cat.items.map((x) => x.id)).toEqual(["ok"]);
+  });
+
+  test("drops a Category whose items all become unavailable", async () => {
+    installFetchMock(() => ({ status: 404 }));
+
+    const input: CatalogItem[] = [
+      {
+        type: "Category",
+        id: "cat",
+        shortId: "cat",
+        name: "cat",
+        items: [geojsonItem("a", "https://example.com/a.geojson")],
+      },
+      geojsonItem("survivor", "https://example.com/survivor.geojson"),
+    ];
+
+    // survivor also 404s in this mock, so we expect both gone
+    const out = await filterUnavailableGeojsonItems(input);
+
+    expect(out).toEqual([]);
+  });
+
+  test("handles nested categories recursively and drops empty parents", async () => {
+    installFetchMock((url) => (url.endsWith("/missing.geojson") ? { status: 404 } : { status: 200 }));
+
+    const input: CatalogItem[] = [
+      {
+        type: "Category",
+        id: "outer",
+        shortId: "outer",
+        name: "outer",
+        items: [
+          {
+            type: "Category",
+            id: "innerAllMissing",
+            shortId: "innerAllMissing",
+            name: "innerAllMissing",
+            items: [geojsonItem("a", "https://example.com/missing.geojson")],
+          },
+          {
+            type: "Category",
+            id: "innerOk",
+            shortId: "innerOk",
+            name: "innerOk",
+            items: [geojsonItem("b", "https://example.com/ok.geojson")],
+          },
+        ],
+      },
+    ];
+
+    const out = await filterUnavailableGeojsonItems(input);
+
+    expect(out).toHaveLength(1);
+    const outer = out[0];
+    if (outer.type !== "Category") throw new Error("expected outer Category");
+    expect(outer.items).toHaveLength(1);
+    expect(outer.items[0].id).toBe("innerOk");
+  });
+});

--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -63,10 +63,52 @@ export type CatalogCategory = {
 
 export type CatalogItem = CatalogDataItem | CatalogCategory
 
+const probeIsAvailable = async (url: string): Promise<boolean> => {
+  try {
+    const res = await fetch(url, { method: 'HEAD' });
+    return res.status !== 404;
+  } catch {
+    return true;
+  }
+}
+
+export const filterUnavailableGeojsonItems = async (items: CatalogItem[]): Promise<CatalogItem[]> => {
+  const urls = new Set<string>();
+  for (const item of walkCategories(items)) {
+    if ("geojsonEndpoint" in item) {
+      urls.add(item.geojsonEndpoint);
+    }
+  }
+
+  const probeResults = await Promise.all(
+    [...urls].map(async (url) => [url, await probeIsAvailable(url)] as const),
+  );
+  const availability = new Map(probeResults);
+
+  const filter = (items: CatalogItem[]): CatalogItem[] => {
+    const out: CatalogItem[] = [];
+    for (const item of items) {
+      if (item.type === "Category") {
+        const filteredItems = filter(item.items);
+        if (filteredItems.length > 0) {
+          out.push({ ...item, items: filteredItems });
+        }
+      } else if ("geojsonEndpoint" in item && availability.get(item.geojsonEndpoint) === false) {
+        // 404 — drop this item
+      } else {
+        out.push(item);
+      }
+    }
+    return out;
+  };
+
+  return filter(items);
+}
+
 export const getCatalog: () => Promise<CatalogItem[]> = async () => {
   const res = await fetch('./api/catalog.json');
   const data: CatalogItem[] = await res.json();
-  return data;
+  return filterUnavailableGeojsonItems(data);
 }
 
 export function *walkCategories(data: CatalogItem[]): Generator<CatalogDataItem, void, unknown> {


### PR DESCRIPTION
## Summary
- `getCatalog()` の中で、各 `geojsonEndpoint` の URL に並列で HEAD リクエストを投げ、ステータスが **404** のアイテムをサイドバーから除外するようにした。
- 404 のせいでアイテム全部が消えた Category は、そのカテゴリーごとサイドバーから除外する。
- ネットワークエラー / CORS 失敗 / 5xx など 404 以外の応答では保守的にメニューを残す（正常なデータを誤って隠さないため）。

## なんで
カタログには `geojsonEndpoint` を指定する DataItem が含まれるが、URL が 404 になっているもの（例: `municipal_hospital`）もサイドバーには表示されていた。ユーザーがチェックを入れても何も表示できないので、最初から非表示にする方が親切。

## 動作確認
- `npm test`: 全 18 テスト pass（新規 8 テスト含む）
  - 404 のアイテムが除外される / 200 のアイテムは残る / 非 geojson アイテムは触らない / ネットワークエラー時は残す / 5xx は残す / 空の Category は除外 / ネストしたカテゴリーで再帰的に動く
- `npx tsc --noEmit`: ✓
- `npm run build`: ✓

## 影響範囲
- 影響を受けるのは `getCatalog()` の戻り値だけ。呼び出し側（`atoms.ts` / `Sidebar.tsx` / `MainMap.tsx`）の変更は不要。
- 初回ロード時に 86 件の HEAD リクエストが並列で走る（体感 +0.5〜1 秒程度）。

## Test plan
- [ ] サイドバーを開いて、`municipal_hospital`（市民病院）の項目が出ていないことを確認
- [ ] 他の 200 系のアイテム（例: AED 設置場所）が引き続き表示されていることを確認
- [ ] ブラウザのネットワークパネルで `opendata.takamatsu-fact.com/**/data.geojson` への HEAD リクエストが並列で走っていることを確認
- [ ] オフラインでサイトを開いたとき、メニューが空にならず通常通り表示されることを確認（ネットワークエラーは保守的に「表示残す」扱い）