### PR TITLE
商店街通行量情報レイヤから削除された属性を除去

### DIFF
--- a/src/utils/visibilityConversion.ts
+++ b/src/utils/visibilityConversion.ts
@@ -397,13 +397,7 @@ const displayConversion: DisplayConversionType = (features: CatalogFeature): Cat
     '商店街通行量情報': {
       'name':'名称',
       'surveyDate':'調査日',
-      'manWeekdaysAverage':'男性平日平均',
-      'womanWeekdaysAverage':'女性平日平均',
-      'bicycleWeekdaysAverage':'自転車平日平均',
       'totalWeekdaysAverage':'合計平日平均',
-      'manHolidayAverage':'男性休日平均',
-      'womanHolidayAverage':'女性休日平均',
-      'bicycleHolidayAverage':'自転車休日平均',
       'totalHolidayAverage':'休日平均合計',
     },
     '指定緊急避難場所・指定避難所': {


### PR DESCRIPTION
## 概要

計測システムの変更に伴い、商店街通行量情報のオープンデータから一部の属性が削除されました。
スマートマップ側の表示属性マッピング（`src/utils/visibilityConversion.ts`）からも、対応する属性を除去します。

## 削除した属性

- 男性平日平均 (`manWeekdaysAverage`)
- 女性平日平均 (`womanWeekdaysAverage`)
- 自転車平日平均 (`bicycleWeekdaysAverage`)
- 男性休日平均 (`manHolidayAverage`)
- 女性休日平均 (`womanHolidayAverage`)
- 自転車休日平均 (`bicycleHolidayAverage`)

## 残す属性

- 名称 (`name`)
- 調査日 (`surveyDate`)
- 合計平日平均 (`totalWeekdaysAverage`)
- 休日平均合計 (`totalHolidayAverage`)

## 確認

オープンデータの現在の属性が `name` / `surveyDate` / `totalWeekdaysAverage` / `totalHolidayAverage` の4つのみであることを確認済み。
(参照: https://opendata.takamatsu-fact.com/shopping_street_traffic_information/data.geojson )