### PR TITLE
診療所レイヤを削除（オープンデータ公開終了）

### DIFF
--- a/public/api/catalog.json
+++ b/public/api/catalog.json
@@ -869,15 +869,6 @@
           },
           {
             "type": "DataItem",
-            "id": "施設情報/保健・医療・福祉/診療所",
-            "shortId": "3UK",
-            "name": "診療所",
-            "class": "診療所",
-            "geojsonEndpoint": "https://opendata.takamatsu-fact.com/clinic/data.geojson",
-            "metadata": {}
-          },
-          {
-            "type": "DataItem",
             "id": "施設情報/保健・医療・福祉/柔道整復師施術所一覧",
             "shortId": "8Mb",
             "name": "柔道整復師施術所一覧",

--- a/src/utils/visibilityConversion.ts
+++ b/src/utils/visibilityConversion.ts
@@ -332,18 +332,6 @@ const displayConversion: DisplayConversionType = (features: CatalogFeature): Cat
     '老人福祉センターなど': pattern4,
     '老人福祉施設': pattern4,
     '小規模多機能型居宅介護施設': pattern4,
-    '診療所': {
-      'name':'名称',
-      'nickname':'ニックネーム',
-      'address':'住所',
-      'telephoneNumber':'電話番号',
-      'referenceObject':'参照先',
-      'note':'備考',
-      'availableDate':'利用可能日',
-      'startTime':'開始時刻',
-      'endTime':'終了時刻',
-      'availableDateNote':'利用可能日備考',
-    },
     '企業主導型保育施設一覧': pattern5,
     '認可外保育施設一覧': pattern5,
     '病児・病後児保育施設': {


### PR DESCRIPTION
## 概要
高松市都市計画課より、「診療所」のオープンデータ公開終了に伴い、スマートマップから診療所レイヤを削除する依頼を受領（2026-06-15 今津様メール）。

## 変更内容
- `public/api/catalog.json`: 診療所 DataItem（`施設情報/保健・医療・福祉/診療所`）を削除
- `src/utils/visibilityConversion.ts`: 診療所の詳細表示項目変換ブロックを削除

市立病院レイヤ削除（#209）と同じ手順。

## 確認
- [ ] Deploy Preview で診療所レイヤがサイドメニューから消えていること

依頼元: マイセーフティマップ側（takamatsu-city-safety-map）でも同様に削除対応。