### PR TITLE
許可盛土データ更新（ID105氏名修正・ID59工期変更・ID112新規）＋配信元をsmartcity直配信へ切替

### DIFF
--- a/public/api/catalog.json
+++ b/public/api/catalog.json
@@ -1427,7 +1427,7 @@
         "name": "許可盛土",
         "class": "許可盛土",
         "source_type": "vector",
-        "tileUrl": "https://tileserver.geolonia.com/takamatsu_morido_allowed_260617/tiles.json?key=YOUR-API-KEY",
+        "tileUrl": "https://tileserver.geolonia.com/takamatsu_morido_allowed_260702/tiles.json?key=YOUR-API-KEY",
         "customDataSourceLayer": "許可盛土",
         "metadata": {
           "attributesOrder": [

--- a/public/api/catalog.json
+++ b/public/api/catalog.json
@@ -1427,7 +1427,7 @@
         "name": "許可盛土",
         "class": "許可盛土",
         "source_type": "vector",
-        "tileUrl": "https://tileserver.geolonia.com/takamatsu_morido_allowed_260508/tiles.json?key=YOUR-API-KEY",
+        "tileUrl": "https://tileserver.geolonia.com/takamatsu_morido_allowed_260617/tiles.json?key=YOUR-API-KEY",
         "customDataSourceLayer": "許可盛土",
         "metadata": {
           "attributesOrder": [

--- a/public/api/catalog.json
+++ b/public/api/catalog.json
@@ -1427,8 +1427,8 @@
         "name": "許可盛土",
         "class": "許可盛土",
         "source_type": "vector",
-        "tileUrl": "https://tileserver.geolonia.com/takamatsu_morido_allowed_260702/tiles.json?key=YOUR-API-KEY",
-        "customDataSourceLayer": "許可盛土",
+        "tileUrl": "https://takamatsu-city.kagawa.smartcity.geolonia.com/data/morido-allowed/latest/tiles/tiles.json",
+        "customDataSourceLayer": "g-simplestyle-v1",
         "metadata": {
           "attributesOrder": [
             "ID",


### PR DESCRIPTION
## 概要
高松市 建築指導課（山地さん）依頼の許可盛土データ更新（ID105・ID59・ID112）を反映。
あわせて、許可盛土レイヤの**配信元を smartcity 直配信へ切替**える。

## データ変更（ソース: geolonia/takamatsu-ops-2026 `data/盛土/許可盛土.geojson`）
| ID | 区分 | 変更 |
|----|------|------|
| ID105 | 変更（公表中） | 工事主の氏名の誤記修正（`Flom1.st`→`From1.st`） |
| ID59 | 変更（届出受理） | 工事着手 `2026-01-15`→`2026-07-31`、工事完了予定 `2026-07-31`→`2027-07-30` |
| ID112 | 新規（許可） | 新規追加。許可番号「高建指第４号」付与、許可年月日 `2026-06-26` |

## 配信元の切替（重要）
- 変更前: `tileUrl` = `tileserver.geolonia.com/takamatsu_morido_allowed_*`（PMTiles）
- 変更後: `tileUrl` = `https://takamatsu-city.kagawa.smartcity.geolonia.com/data/morido-allowed/latest/tiles/tiles.json`（smartcity 直配信・keyなし）
- `customDataSourceLayer`: `許可盛土` → `g-simplestyle-v1`

### 背景
- 2026-06-29 の tileserver SAM 移行（`geolonia/tileserverless-infra#49`）で `geolonia-admin pmtiles deploy v1` の配信先が新本番とズレ、新規タイルの tiles.json が404になる事象が発生。
- 恒久対応として、許可盛土を smartcity バケット（XYZベクトルタイル直配信）へ移行。GeonicDB直配信化（geolonia/takamatsu-ops-2026#119）の前倒し。

## マージ条件
- ID105 / ID59：既公表データの修正のため、顧客確認後にマージ可。
- **ID112：許可日（2026-06-26 予定）の確定を顧客に確認のうえマージ**。